### PR TITLE
Add arm64-Targets

### DIFF
--- a/kmm/androidApp/build.gradle.kts
+++ b/kmm/androidApp/build.gradle.kts
@@ -11,11 +11,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion(30)
+    compileSdk = 32
     defaultConfig {
         applicationId = "io.github.fededri.arch.android"
-        minSdkVersion(23)
-        targetSdkVersion(30)
+        minSdk = 23
+        targetSdk = 32
         versionCode = 1
         versionName = "1.0"
     }

--- a/kmm/build.gradle.kts
+++ b/kmm/build.gradle.kts
@@ -5,8 +5,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.30")
-        classpath("com.android.tools.build:gradle:7.0.2")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
+        classpath("com.android.tools.build:gradle:7.2.1")
     }
 }
 

--- a/kmm/gradle.properties
+++ b/kmm/gradle.properties
@@ -6,5 +6,3 @@ kotlin.code.style=official
 
 #Android
 android.useAndroidX=true
-
-org.gradle.java.home=/Users/federicotorres/Library/Java/JavaVirtualMachines/adopt-openj9-11.0.11/Contents/Home

--- a/kmm/gradle/wrapper/gradle-wrapper.properties
+++ b/kmm/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Sep 04 16:58:53 ART 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/kmm/shared/build.gradle.kts
+++ b/kmm/shared/build.gradle.kts
@@ -20,11 +20,9 @@ version = "0.5"
 
 kotlin {
     android()
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget = when {
-        System.getenv("SDK_NAME")?.startsWith("iphoneos") == true -> ::iosArm64
-        else -> ::iosX64
-    }
-    iosTarget("ios") {}
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
     cocoapods {
         summary = "Some description for the Shared Module"
         homepage = "Link to the Shared Module homepage"
@@ -44,7 +42,15 @@ kotlin {
                 implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version")
             }
         }
-        val iosMain by getting
+        val iosX64Main by getting
+        val iosArm64Main by getting
+        val iosSimulatorArm64Main by getting
+        val iosMain by creating {
+            dependsOn(commonMain)
+            iosX64Main.dependsOn(this)
+            iosArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
+        }
     }
     android {
         publishAllLibraryVariants()
@@ -105,10 +111,10 @@ signing {
     sign(publishing.publications)
 }
 android {
-    compileSdkVersion(30)
+    compileSdkVersion(32)
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
         minSdkVersion(21)
-        targetSdkVersion(30)
+        targetSdkVersion(32)
     }
 }


### PR DESCRIPTION
For easier ARM-Usage I added the targets always to the lib. Would be nice to add them for future usage. This fixes also Issue #1  

(Version update is missing and removing the dependency from the iOS-Sourset in the documentation)